### PR TITLE
Fix threshold rule generation with settings defined on the sigma rule

### DIFF
--- a/rule_file_creator_scripts/es_qs.py
+++ b/rule_file_creator_scripts/es_qs.py
@@ -322,7 +322,6 @@ def install_rules(script_dir, credentials, rule_file, logger):
 def rate_based_rule_settings(sigma_config, config, config_t, yj_rule_t, logger):
     # directly make changes to config variable and then return it at the end
     temp = {}
-    configtemp = {}
     update_required = False
     try:
         logger.debug('if else starting...')
@@ -335,7 +334,7 @@ def rate_based_rule_settings(sigma_config, config, config_t, yj_rule_t, logger):
                 # if in the rule, field or value under threshold are empty or null, then rule is not rate based.
                 if yj_rule_t.get('field') is None or yj_rule_t.get('value') is None: break
                 if yj_rule_t.get('field') is not None and yj_rule_t.get('value') is not None and type(yj_rule_t.get('value')) == int: 
-                # if threshold is not defined in siegma config
+                # if threshold is defined in rule
                     temp = yj_rule_t
                     update_required = True
                     logger.debug('rule threshold set...')
@@ -343,7 +342,7 @@ def rate_based_rule_settings(sigma_config, config, config_t, yj_rule_t, logger):
             elif (not update_required) and config_t and config_t.get('field') is not None and config_t.get('value') is not None and type(config_t.get('value')) == int: 
             # elif (not update_required) and config_t and config_t.get('value') and type(config_t.get('value')) == int: 
                 # if threshold is defined in siegma config
-                configtemp = config_t
+                temp = config_t
                 update_required = True
                 logger.debug('config threshold set...')
             else: logger.debug('temp is empty...')
@@ -353,10 +352,10 @@ def rate_based_rule_settings(sigma_config, config, config_t, yj_rule_t, logger):
             # handle empty field gracefully
             # t = temp.get('field')
             # logger.debug(f'temp.field: {t}')
-            if configtemp.get('field') and configtemp.get('field') != '': 
-                ecs_field = sigma_config.get('fieldmappings').get(temp.get('field'))
-            else:
-                ecs_field = temp.get('field')
+            # try to convert threshold field to sigma mapped field.
+            if temp.get('field') and temp.get('field') != '' and sigma_config.get('fieldmappings').get(temp.get('field')) is not None: ecs_field = sigma_config.get('fieldmappings').get(temp.get('field'))
+            # if conversion fails, then consider whatever value was in the threshold.field as ecs formatted and move forward with that
+            else: ecs_field = temp.get('field')
             config['threshold'] = {
                 'field' : ecs_field,
                 'value': temp.get('value')

--- a/rule_file_creator_scripts/es_qs.py
+++ b/rule_file_creator_scripts/es_qs.py
@@ -322,6 +322,7 @@ def install_rules(script_dir, credentials, rule_file, logger):
 def rate_based_rule_settings(sigma_config, config, config_t, yj_rule_t, logger):
     # directly make changes to config variable and then return it at the end
     temp = {}
+    configtemp = {}
     update_required = False
     try:
         logger.debug('if else starting...')
@@ -341,8 +342,8 @@ def rate_based_rule_settings(sigma_config, config, config_t, yj_rule_t, logger):
             # elif (not update_required) and config_t and config_t.get('field') and (not config_t.get('field') == '') and config_t.get('value') and type(config_t.get('value')) == int: 
             elif (not update_required) and config_t and config_t.get('field') is not None and config_t.get('value') is not None and type(config_t.get('value')) == int: 
             # elif (not update_required) and config_t and config_t.get('value') and type(config_t.get('value')) == int: 
-                # if threshold is not defined in siegma config
-                temp = config_t
+                # if threshold is defined in siegma config
+                configtemp = config_t
                 update_required = True
                 logger.debug('config threshold set...')
             else: logger.debug('temp is empty...')
@@ -352,7 +353,10 @@ def rate_based_rule_settings(sigma_config, config, config_t, yj_rule_t, logger):
             # handle empty field gracefully
             # t = temp.get('field')
             # logger.debug(f'temp.field: {t}')
-            if temp.get('field') and temp.get('field') != '': ecs_field = sigma_config.get('fieldmappings').get(temp.get('field'))
+            if configtemp.get('field') and configtemp.get('field') != '': 
+                ecs_field = sigma_config.get('fieldmappings').get(temp.get('field'))
+            else:
+                ecs_field = temp.get('field')
             config['threshold'] = {
                 'field' : ecs_field,
                 'value': temp.get('value')


### PR DESCRIPTION
Adds a different variable for threshold settings defined by the config file, this way the threshold settings defined on the rule can be used.

Example of the bug:

Rule file:
![image](https://user-images.githubusercontent.com/26856693/110569784-bbdbee00-8133-11eb-98c5-83da535442cd.png)

Result:
![image](https://user-images.githubusercontent.com/26856693/110569835-d0b88180-8133-11eb-9e64-5331c404ed0a.png)
